### PR TITLE
add launch page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/src/pages/launch.astro
+++ b/src/pages/launch.astro
@@ -1,0 +1,55 @@
+---
+import MainHead from '../components/MainHead.astro';
+const title = "Grow traffic and revenue with SEO Content | SwatSEO";
+const description = "Increasing your traffic and revenue through data-driven SEO is easy with SwatSEO's our tailored conversion-focused strategy.";
+const ogTitle = title;
+const ogDescription = description;
+const ogImage = "https://swatseo.vercel.app/opengraph-image.png";
+const website = "https://swatseo.vercel.app/"
+---
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <MainHead
+      title={title}
+      description={description}
+    />
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content={website} />
+    <meta property="og:title" content={ogTitle} />
+    <meta property="og:description" content={ogDescription} />
+    <meta property="og:image" content={ogImage} />
+
+    <!-- Twitter -->
+    <meta property="twitter:card" content="summary_large_image" />
+    <meta property="twitter:url" content={website} />
+    <meta property="twitter:title" content={ogTitle} />
+    <meta property="twitter:description" content={ogDescription} />
+    <meta property="twitter:image" content={ogImage} />
+
+  </head>
+
+  <style>
+    body, html {
+      margin: 0;
+      padding: 0;
+      width: 100%;
+      height: 100%;
+    }
+    iframe {
+      border: none;
+      width: 100%;
+      height: 100vh; /* Full viewport height */
+    }
+  </style>
+</head>
+<body>
+  <iframe src={website} allowfullscreen></iframe>
+</body>
+</html>


### PR DESCRIPTION
**PR: SEO Meta Tags for Launch Page**

Description:

This PR adds SEO meta tags to the Launch Page, including title, description, Open Graph metadata, and Twitter metadata. The meta tags are used to optimize the page for search engines and social media platforms.



Changes:

- Added `title` and `description` constants for the page
- Set `ogTitle` and `ogDescription` to the same values as `title` and `description`
- Set `ogImage` to the URL of the Open Graph image
- Set `website` to the URL of the SwatSEO website
- Added meta tags for Open Graph and Twitter metadata
